### PR TITLE
Added yosys+verific template scripts.

### DIFF
--- a/scripts/yosys_templates/qlf_yosys+verific.ys
+++ b/scripts/yosys_templates/qlf_yosys+verific.ys
@@ -1,0 +1,17 @@
+# Yosys synthesis script for ${TOP_MODULE}
+# Print all commands to log before executing them.
+echo on
+# Add include directory for Verific mode
+${ADD_INCLUDE_DIR}
+# Add library directory for Verific mode
+${ADD_LIBRARY_DIR}
+# Read hdl files into specified library
+${READ_LIBRARY}
+# Read hdl files
+${READ_HDL_FILE}
+# Import to Yosys for Verific mode
+verific -import -all ${TOP_MODULE}
+
+synth_quicklogic -blif ${OUTPUT_BLIF} -top ${TOP_MODULE} ${YOSYS_ARGS}
+
+write_verilog -noattr -nohex ${OUTPUT_VERILOG}

--- a/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_bram_dsp_dff_flow.ys
+++ b/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_bram_dsp_dff_flow.ys
@@ -1,0 +1,113 @@
+# Yosys synthesis script for ${TOP_MODULE}
+
+# Print all commands to log before executing them.
+echo on
+#########################
+# Parse input files
+#########################
+# Add include directory for Verific mode
+${ADD_INCLUDE_DIR}
+# Add library directory for Verific mode
+${ADD_LIBRARY_DIR}
+# Read hdl files into specified library
+${READ_LIBRARY}
+# Read hdl files
+${READ_HDL_FILE}
+# Import to Yosys for Verific mode
+verific -import -all ${TOP_MODULE}
+# Mark cell simulation library modules as BLACKBOX
+${ADD_BLACKBOX_MODULES}
+
+#########################
+# Prepare for synthesis
+#########################
+# Identify top module from hierarchy
+hierarchy -check -top ${TOP_MODULE}
+# Flatten all the gates/primitives
+flatten
+# Identify tri-state buffers from 'z' signal in AST
+# with follow-up optimizations to clean up AST
+tribuf -logic
+opt_expr
+opt_clean
+# demote inout ports to input or output port
+# with follow-up optimizations to clean up AST
+deminout
+opt -nodffe -nosdff
+
+opt_expr
+opt_clean
+check
+opt -nodffe -nosdff
+wreduce -keepdc
+peepopt
+pmuxtree
+opt_clean
+
+########################
+# Map multipliers
+# Inspired from synth_xilinx.cc
+#########################
+# Avoid merging any registers into DSP, reserve memory port registers first
+memory_dff
+wreduce t:$mul
+techmap -map +/mul2dsp.v -map ${YOSYS_DSP_MAP_VERILOG} ${YOSYS_DSP_MAP_PARAMETERS}
+select a:mul2dsp
+setattr -unset mul2dsp
+opt_expr -fine
+wreduce
+select -clear
+chtype -set $mul t:$__soft_mul # Extract arithmetic functions
+
+#########################
+# Run coarse synthesis
+#########################
+# Run a tech map with default library
+techmap
+alumacc
+share
+opt -nodffe -nosdff
+fsm
+# Run a quick follow-up optimization to sweep out unused nets/signals
+opt -fast -nodffe -nosdff
+# Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
+memory -nomap
+opt_clean
+
+#########################
+# Map logics to BRAMs
+#########################
+memory_bram -rules ${YOSYS_BRAM_MAP_RULES}
+techmap -map ${YOSYS_BRAM_MAP_VERILOG}
+opt -fast -mux_undef -undriven -fine -nodffe -nosdff
+memory_map
+opt -undriven -fine -nodffe -nosdff
+
+#########################
+# Map flip-flops
+#########################
+techmap -map ${YOSYS_DFF_MAP_VERILOG}
+opt_expr -mux_undef
+simplemap
+opt_expr
+opt_merge
+opt_dff -nodffe -nosdff
+opt_clean
+opt -nodffe -nosdff
+
+#########################
+# Map LUTs
+#########################
+abc -lut ${LUT_SIZE}
+
+#########################
+# Check and show statisitics
+#########################
+hierarchy -check
+stat
+
+#########################
+# Output netlists
+#########################
+opt_clean -purge
+write_blif ${OUTPUT_BLIF}

--- a/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_bram_dsp_flow.ys
+++ b/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_bram_dsp_flow.ys
@@ -1,0 +1,114 @@
+# Yosys synthesis script for ${TOP_MODULE}
+
+# Print all commands to log before executing them.
+echo on
+#########################
+# Parse input files
+#########################
+# Add include directory for Verific mode
+${ADD_INCLUDE_DIR}
+# Add library directory for Verific mode
+${ADD_LIBRARY_DIR}
+# Read hdl files into specified library
+${READ_LIBRARY}
+# Read hdl files
+${READ_HDL_FILE}
+# Import to Yosys for Verific mode
+verific -import -all ${TOP_MODULE}
+# Mark cell simulation library modules as BLACKBOX
+${ADD_BLACKBOX_MODULES}
+
+#########################
+# Prepare for synthesis
+#########################
+# Identify top module from hierarchy
+hierarchy -check -top ${TOP_MODULE}
+# Flatten all the gates/primitives
+flatten
+# Identify tri-state buffers from 'z' signal in AST
+# with follow-up optimizations to clean up AST
+tribuf -logic
+opt_expr
+opt_clean
+# demote inout ports to input or output port
+# with follow-up optimizations to clean up AST
+deminout
+opt -nodffe -nosdff
+
+opt_expr
+opt_clean
+check
+opt -nodffe -nosdff
+wreduce -keepdc
+peepopt
+pmuxtree
+opt_clean
+
+########################
+# Map multipliers
+# Inspired from synth_xilinx.cc
+#########################
+# Avoid merging any registers into DSP, reserve memory port registers first
+memory_dff
+wreduce t:$mul
+techmap -map +/mul2dsp.v -map ${YOSYS_DSP_MAP_VERILOG} ${YOSYS_DSP_MAP_PARAMETERS}
+select a:mul2dsp
+setattr -unset mul2dsp
+opt_expr -fine
+wreduce
+select -clear
+chtype -set $mul t:$__soft_mul # Extract arithmetic functions
+
+#########################
+# Run coarse synthesis
+#########################
+# Run a tech map with default library
+techmap
+alumacc
+share
+opt -nodffe -nosdff
+fsm
+# Run a quick follow-up optimization to sweep out unused nets/signals
+opt -fast -nodffe -nosdff
+# Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
+memory -nomap
+opt_clean
+
+#########################
+# Map logics to BRAMs
+#########################
+memory_bram -rules ${YOSYS_BRAM_MAP_RULES}
+techmap -map ${YOSYS_BRAM_MAP_VERILOG}
+opt -fast -mux_undef -undriven -fine -nodffe -nosdff
+memory_map
+opt -undriven -fine -nodffe -nosdff
+
+#########################
+# Map flip-flops
+#########################
+dfflegalize -cell $_DFF_P_ 0
+techmap -map +/adff2dff.v
+opt_expr -mux_undef
+simplemap
+opt_expr
+opt_merge
+opt_dff -nodffe -nosdff
+opt_clean
+opt -nodffe -nosdff
+
+#########################
+# Map LUTs
+#########################
+abc -lut ${LUT_SIZE}
+
+#########################
+# Check and show statisitics
+#########################
+hierarchy -check
+stat
+
+#########################
+# Output netlists
+#########################
+opt_clean -purge
+write_blif ${OUTPUT_BLIF}

--- a/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_bram_flow.ys
+++ b/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_bram_flow.ys
@@ -1,0 +1,99 @@
+# Yosys synthesis script for ${TOP_MODULE}
+
+# Print all commands to log before executing them.
+echo on
+#########################
+# Parse input files
+#########################
+# Add include directory for Verific mode
+${ADD_INCLUDE_DIR}
+# Add library directory for Verific mode
+${ADD_LIBRARY_DIR}
+# Read hdl files into specified library
+${READ_LIBRARY}
+# Read hdl files
+${READ_HDL_FILE}
+# Import to Yosys for Verific mode
+verific -import -all ${TOP_MODULE}
+# Mark cell simulation library modules as BLACKBOX
+${ADD_BLACKBOX_MODULES}
+
+#########################
+# Prepare for synthesis
+#########################
+# Identify top module from hierarchy
+hierarchy -check -top ${TOP_MODULE}
+# Flatten all the gates/primitives
+flatten
+# Identify tri-state buffers from 'z' signal in AST
+# with follow-up optimizations to clean up AST
+tribuf -logic
+opt_expr
+opt_clean
+# demote inout ports to input or output port
+# with follow-up optimizations to clean up AST
+deminout
+opt -nodffe -nosdff
+
+opt_expr
+opt_clean
+check
+opt -nodffe -nosdff
+wreduce -keepdc
+peepopt
+pmuxtree
+opt_clean
+
+#########################
+# Run coarse synthesis
+#########################
+# Extract arithmetic functions
+alumacc
+share
+opt -nodffe -nosdff
+fsm
+# Run a quick follow-up optimization to sweep out unused nets/signals
+# FIXME: In Yosys v0.10, when options '-nodffe' and '-nosdff' is on, some dual-port ram cannot be inferred correctly
+opt -fast #-nodffe -nosdff
+# Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
+memory -nomap
+opt_clean
+
+#########################
+# Map logics to BRAMs
+#########################
+memory_bram -rules ${YOSYS_BRAM_MAP_RULES}
+techmap -map ${YOSYS_BRAM_MAP_VERILOG}
+opt -fast -mux_undef -undriven -fine -nodffe -nosdff
+memory_map
+opt -undriven -fine -nodffe -nosdff
+
+#########################
+# Map flip-flops
+#########################
+dfflegalize -cell $_DFF_P_ 0
+techmap -map +/adff2dff.v
+opt_expr -mux_undef
+simplemap
+opt_expr
+opt_merge
+opt_dff -nodffe -nosdff
+opt_clean
+opt -nodffe -nosdff
+
+#########################
+# Map LUTs
+#########################
+abc -lut ${LUT_SIZE}
+
+#########################
+# Check and show statisitics
+#########################
+hierarchy -check
+stat
+
+#########################
+# Output netlists
+#########################
+opt_clean -purge
+write_blif ${OUTPUT_BLIF}

--- a/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_dff_flow.ys
+++ b/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_dff_flow.ys
@@ -1,0 +1,54 @@
+# Yosys synthesis script for ${TOP_MODULE}
+
+# Print all commands to log before executing them.
+echo on
+# Add include directory for Verific mode
+${ADD_INCLUDE_DIR}
+# Add library directory for Verific mode
+${ADD_LIBRARY_DIR}
+# Read hdl files into specified library
+${READ_LIBRARY}
+# Read hdl files
+${READ_HDL_FILE}
+# Import to Yosys for Verific mode
+verific -import -all ${TOP_MODULE}
+# Mark cell simulation library modules as BLACKBOX
+${ADD_BLACKBOX_MODULES}
+
+# Technology mapping
+hierarchy -top ${TOP_MODULE}
+techmap -D NO_LUT -map ${YOSYS_DFF_MAP_VERILOG}
+
+# Synthesis
+flatten
+opt_expr
+opt_clean
+check
+opt -nodffe -nosdff
+fsm
+opt -nodffe -nosdff
+wreduce
+peepopt
+opt_clean
+opt -nodffe -nosdff
+memory -nomap
+opt_clean
+opt -fast -full -nodffe -nosdff
+memory_map
+opt -full -nodffe -nosdff
+techmap
+opt -fast -nodffe -nosdff
+clean
+
+# LUT mapping
+abc -lut ${LUT_SIZE}
+
+# FF mapping
+techmap -D NO_LUT -map ${YOSYS_DFF_MAP_VERILOG}
+
+# Check
+synth -run check
+
+# Clean and output blif
+opt_clean -purge
+write_blif ${OUTPUT_BLIF}

--- a/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_dsp_flow.ys
+++ b/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_dsp_flow.ys
@@ -1,0 +1,105 @@
+# Yosys synthesis script for ${TOP_MODULE}
+
+# Print all commands to log before executing them.
+echo on
+#########################
+# Parse input files
+#########################
+# Add include directory for Verific mode
+${ADD_INCLUDE_DIR}
+# Add library directory for Verific mode
+${ADD_LIBRARY_DIR}
+# Read hdl files into specified library
+${READ_LIBRARY}
+# Read hdl files
+${READ_HDL_FILE}
+# Import to Yosys for Verific mode
+verific -import -all ${TOP_MODULE}
+# Mark cell simulation library modules as BLACKBOX
+${ADD_BLACKBOX_MODULES}
+
+#########################
+# Prepare for synthesis
+#########################
+# Identify top module from hierarchy
+hierarchy -check -top ${TOP_MODULE}
+# Flatten all the gates/primitives
+flatten
+# Identify tri-state buffers from 'z' signal in AST
+# with follow-up optimizations to clean up AST
+tribuf -logic
+opt_expr
+opt_clean
+# demote inout ports to input or output port
+# with follow-up optimizations to clean up AST
+deminout
+opt -nodffe -nosdff
+
+opt_expr
+opt_clean
+check
+opt -nodffe -nosdff
+wreduce -keepdc
+peepopt
+pmuxtree
+opt_clean
+
+########################
+# Map multipliers
+# Inspired from synth_xilinx.cc
+#########################
+# Avoid merging any registers into DSP, reserve memory port registers first
+memory_dff
+wreduce t:$mul
+techmap -map +/mul2dsp.v -map ${YOSYS_DSP_MAP_VERILOG} ${YOSYS_DSP_MAP_PARAMETERS}
+select a:mul2dsp
+setattr -unset mul2dsp
+opt_expr -fine
+wreduce
+select -clear
+chtype -set $mul t:$__soft_mul # Extract arithmetic functions
+
+#########################
+# Run coarse synthesis
+#########################
+# Run a tech map with default library
+techmap
+alumacc
+share
+opt -nodffe -nosdff
+fsm
+# Run a quick follow-up optimization to sweep out unused nets/signals
+opt -fast -nodffe -nosdff
+# Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
+memory -nomap
+opt_clean
+
+#########################
+# Map flip-flops
+#########################
+dfflegalize -cell $_DFF_P_ 0
+techmap -map +/adff2dff.v
+opt_expr -mux_undef
+simplemap
+opt_expr
+opt_merge
+opt_dff -nodffe -nosdff
+opt_clean
+opt -nodffe -nosdff
+
+#########################
+# Map LUTs
+#########################
+abc -lut ${LUT_SIZE}
+
+#########################
+# Check and show statisitics
+#########################
+hierarchy -check
+stat
+
+#########################
+# Output netlists
+#########################
+opt_clean -purge
+write_blif ${OUTPUT_BLIF}

--- a/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys
+++ b/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys
@@ -1,0 +1,49 @@
+# Yosys synthesis script for ${TOP_MODULE}
+
+# Print all commands to log before executing them.
+echo on
+# Add include directory for Verific mode
+${ADD_INCLUDE_DIR}
+# Add library directory for Verific mode
+${ADD_LIBRARY_DIR}
+# Read hdl files into specified library
+${READ_LIBRARY}
+# Read hdl files
+${READ_HDL_FILE}
+# Import to Yosys for Verific mode
+verific -import -all ${TOP_MODULE}
+
+# Technology mapping
+hierarchy -top ${TOP_MODULE}
+techmap -D NO_LUT -map +/adff2dff.v
+
+# Synthesis
+flatten
+opt_expr
+opt_clean
+check
+opt -nodffe -nosdff
+fsm
+opt -nodffe -nosdff
+wreduce
+peepopt
+opt_clean
+opt -nodffe -nosdff
+memory -nomap
+opt_clean
+opt -fast -full -nodffe -nosdff
+memory_map
+opt -full -nodffe -nosdff
+techmap
+opt -fast -nodffe -nosdff
+clean
+
+# LUT mapping
+abc -lut ${LUT_SIZE}
+
+# Check
+synth -run check
+
+# Clean and output blif
+opt_clean -purge
+write_blif ${OUTPUT_BLIF}

--- a/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys
+++ b/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys
@@ -1,0 +1,49 @@
+# Yosys synthesis script for ${TOP_MODULE}
+
+# Print all commands to log before executing them.
+echo on
+# Add include directory for Verific mode
+${ADD_INCLUDE_DIR}
+# Add library directory for Verific mode
+${ADD_LIBRARY_DIR}
+# Read hdl files into specified library
+${READ_LIBRARY}
+# Read hdl files
+${READ_HDL_FILE}
+# Import to Yosys for Verific mode
+verific -import -all ${TOP_MODULE}
+
+# Technology mapping
+hierarchy -top ${TOP_MODULE}
+techmap -D NO_LUT -map +/adff2dff.v
+
+# Synthesis
+flatten
+opt_expr
+opt_clean
+check
+opt -nodffe -nosdff
+fsm
+opt -nodffe -nosdff
+wreduce
+peepopt
+opt_clean
+opt -nodffe -nosdff
+memory -nomap
+opt_clean
+opt -fast -full -nodffe -nosdff
+memory_map
+opt -full -nodffe -nosdff
+techmap
+opt -fast -nodffe -nosdff
+clean
+
+# LUT mapping
+abc -lut ${LUT_SIZE}
+
+# Check
+synth -run check
+
+# Clean and output blif
+opt_clean -purge
+write_blif rewritten_${OUTPUT_BLIF}


### PR DESCRIPTION
This PR closes #1 .
The yosys+verific template scripts are based on existing OpenFPGA yosys scripts. The following are the differences:

- Added `echo on` at the top of each script
- HDL files and technology library reading is converted to verific specific variables
- removed `proc` command
- fixed `chtype -set $mul t:$__soft_mul` command (separated command from the comment). 