### PR TITLE
Added 'discard_config_sections' option and 'ROOT_PATH' variable handling.

### DIFF
--- a/scripts/task_generator/default_settings.json
+++ b/scripts/task_generator/default_settings.json
@@ -7,7 +7,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -19,7 +19,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -31,7 +31,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -43,7 +43,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -55,7 +55,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -67,7 +67,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -79,7 +79,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -91,7 +91,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -103,7 +103,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -115,7 +115,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -127,7 +127,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -139,7 +139,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -151,7 +151,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -163,7 +163,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -175,7 +175,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -187,7 +187,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -199,7 +199,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -211,7 +211,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -223,7 +223,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -235,7 +235,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -247,7 +247,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -259,7 +259,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -271,7 +271,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -283,7 +283,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -295,7 +295,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -307,7 +307,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -319,7 +319,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -331,7 +331,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -343,7 +343,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -355,7 +355,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -367,7 +367,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -379,7 +379,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -391,7 +391,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -403,7 +403,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -415,7 +415,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -427,7 +427,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -439,7 +439,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -451,7 +451,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -463,7 +463,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -475,7 +475,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -487,7 +487,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -499,7 +499,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -511,7 +511,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -523,7 +523,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -535,7 +535,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -547,7 +547,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -559,7 +559,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -571,7 +571,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -583,7 +583,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -595,7 +595,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -607,7 +607,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_bram_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_bram_flow.ys"
             }
         }
     },
@@ -622,8 +622,8 @@
                 "yosys_blackbox_modules": "latchre,dffrn,dffre,dff,dffr"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_dff_flow.ys",
-                "bench_yosys_rewrite_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_dff_flow.ys",
+                "bench_yosys_rewrite_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
             }
         }
     },
@@ -635,7 +635,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -647,7 +647,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -659,7 +659,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -671,7 +671,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -683,7 +683,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -695,7 +695,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -707,7 +707,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -719,7 +719,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -731,7 +731,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -743,7 +743,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -755,7 +755,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -770,7 +770,7 @@
                 "yosys_blackbox_modules": "dpram_1024x8_core,dpram_1024x8,mult_36,dff,dffr,dffs,dffrn,dffsn"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_bram_dsp_dff_flow.ys"
+                "bench_yosys_common": "{ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_bram_dsp_dff_flow.ys"
             }
         }
     },
@@ -788,7 +788,7 @@
                 "bench4": "${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/iwls2005/steppermotordrive/rtl/*.vhd"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_bram_dsp_dff_flow.ys",
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_bram_dsp_dff_flow.ys",
                 "bench4_top": "StepperMotorPorts(StepDrive)"
             }
         }
@@ -804,7 +804,7 @@
                 "yosys_blackbox_modules": "dpram_1024x8_core,dpram_1024x8,mult_36,dff,dffr,dffs,dffrn,dffsn"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_bram_dsp_dff_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_bram_dsp_dff_flow.ys"
             }
         }
     },
@@ -816,7 +816,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -831,7 +831,7 @@
                 "yosys_blackbox_modules": "dpram_1024x8_core,dpram_1024x8,mult_36"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_bram_dsp_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_bram_dsp_flow.ys"
             }
         }
     },
@@ -843,7 +843,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -855,7 +855,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -867,7 +867,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -879,7 +879,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -891,7 +891,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -903,7 +903,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -915,7 +915,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -927,7 +927,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -939,7 +939,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -954,8 +954,8 @@
                 "yosys_blackbox_modules": "dpram_128x8_core,dpram_128x8"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_bram_flow.ys",
-                "bench_yosys_rewrite_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_bram_flow.ys",
+                "bench_yosys_rewrite_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
             }
         }
     },
@@ -970,8 +970,8 @@
                 "yosys_blackbox_modules": "dpram_128x8_core,dpram_128x8"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_bram_flow.ys",
-                "bench_yosys_rewrite_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_bram_flow.ys",
+                "bench_yosys_rewrite_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
             }
         }
     },
@@ -986,8 +986,8 @@
                 "yosys_blackbox_modules": "mult_8,mult_16"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_dsp_flow.ys",
-                "bench_yosys_rewrite_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_dsp_flow.ys",
+                "bench_yosys_rewrite_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
             }
         }
     },
@@ -1002,8 +1002,8 @@
                 "yosys_blackbox_modules": "mult_8"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_dsp_flow.ys",
-                "bench_yosys_rewrite_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_dsp_flow.ys",
+                "bench_yosys_rewrite_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
             }
         }
     },
@@ -1018,8 +1018,8 @@
                 "yosys_blackbox_modules": "mult_8,mult_16"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_dsp_flow.ys",
-                "bench_yosys_rewrite_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_dsp_flow.ys",
+                "bench_yosys_rewrite_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
             }
         }
     },
@@ -1031,7 +1031,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -1043,7 +1043,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -1055,7 +1055,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -1067,7 +1067,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     },
@@ -1079,7 +1079,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench0_yosys": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/qlf_yosys+verific.ys"
+                "bench0_yosys": "${ROOT_PATH}/scripts/yosys_templates/qlf_yosys+verific.ys"
             }
         }
     },
@@ -1091,7 +1091,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/qlf_yosys+verific.ys",
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/qlf_yosys+verific.ys",
                 "bench12_top": "dct_mac(cwidth13)"
             }
         }
@@ -1104,8 +1104,8 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench_yosys_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/qlf_yosys+verific.ys",
-                "bench_yosys_rewrite_common": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
+                "bench_yosys_common": "${ROOT_PATH}/scripts/yosys_templates/qlf_yosys+verific.ys",
+                "bench_yosys_rewrite_common": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys"
             }
         }
     },
@@ -1117,7 +1117,7 @@
                 "verific": "true"
             },
             "SYNTHESIS_PARAM": {
-                "bench0_yosys": "${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys+verific_vpr_flow.ys"
+                "bench0_yosys": "${ROOT_PATH}/scripts/yosys_templates/ys_tmpl_yosys+verific_vpr_flow.ys"
             }
         }
     }

--- a/scripts/task_generator/run_task_generator.py
+++ b/scripts/task_generator/run_task_generator.py
@@ -52,6 +52,7 @@ parser.add_argument("--debug", action="store_true",
 tasks_dir = ""
 generator_settings = None
 reg_tests_list = []
+abs_root_dir = os.path.abspath(os.path.join(__file__, "..", "..", ".."))
 
 def error_exit(msg):
     """Exit with error message"""
@@ -156,10 +157,22 @@ def main():
         except OSError as e:
             error_exit(e.strerror)
 
-        for section, section_settings in task_settings["config_sections"].items():
+        if "discard_config_sections" in task_settings:
+            for section, section_settings in \
+                   task_settings["discard_config_sections"].items():
+                if not section_settings:
+                    task_config[section].clear()
+                else:
+                    task_config_section = task_config[section]
+                    for key in section_settings:
+                        del task_config_section[key]
+
+        for section, section_settings in \
+               task_settings["config_sections"].items():
             task_config_section = task_config[section]
             for key in section_settings:
-                task_config_section[key] = section_settings[key]
+                task_config_section[key] = section_settings[key].\
+                       replace("${ROOT_PATH}", abs_root_dir)
 
         try:
             with open(abs_task_conf, "w") as f:


### PR DESCRIPTION
This PR closes #11 . The following has been done:

- Added `discard_config_sections `property in the settings Json file handling. The property defines configurations which should not be included in the newly generated task.
- Added ${ROOT_PATH} variable support in the settings Json file which is substituted with the yosys_verific_rs repositories absolute path within the task generation script.
- Changed all yosys template scripts paths in default settings file to use 'ROOT_PATH' variable.