### PR TITLE
Fixed subprocess termination and exception issue.

### DIFF
--- a/scripts/synth/synthesis.py
+++ b/scripts/synth/synthesis.py
@@ -46,7 +46,7 @@ logging.basicConfig(
     level=logging.DEBUG,
     format="%(levelname)8s - %(message)s",
     handlers=[
-        logging.FileHandler(logFile),
+        logging.FileHandler(logFile, mode="w"),
         logging.StreamHandler()
     ]
 )


### PR DESCRIPTION
The `subprocess.run` API terminates subprocess in case of timeout, however it doesn't terminate childs of the subprocess. In order to terminate childs of the subprocess we have to used `Popen` constructor with `start_new_session=True` argument and inside the `subprocess.TimeoutExpired` exception handler kill the group of processes by sending `SIGTERM` signal.