### PR TITLE
Added ABC delay optimized scripts.

### DIFF
--- a/scripts/synth/abc/abc_base6.d2.scr
+++ b/scripts/synth/abc/abc_base6.d2.scr
@@ -1,0 +1,30 @@
+write_eqn input.eqn;
+
+&get -n -m; &ps;
+
+&dch ; &if -K 6;
+&ps;
+
+&dch ; &if -K 6;
+&ps;
+
+&dch ; &if -K 6;
+&ps;
+
+&dch ; &if -K 6;
+&ps;
+
+&synch2 ; &if -K 6;
+&ps;
+
+&synch2 ; &if -K 6;
+
+&synch2 ; &if -K 6;
+
+&satlut -d;
+&ps
+
+write_eqn output.eqn;
+
+&put;
+cec input.eqn output.eqn;

--- a/scripts/synth/abc/abc_base6.d3.scr
+++ b/scripts/synth/abc/abc_base6.d3.scr
@@ -1,0 +1,41 @@
+write_eqn input.eqn;
+
+&get -n -m;
+&ps;
+
+&dch; &if -K 6; &save -a;
+&ps;
+
+&b -d; 
+&dch; &if -K 6; &save -a;
+&ps;
+
+&dch; &if -K 6; &save -a;
+&ps;
+
+&b -d; 
+&dch; &if -K 6; &save -a;
+&ps;
+
+&dch; &if -K 6; &save -a;
+&ps;
+
+&synch2; &if -K 6; &save -a;
+&ps;
+
+&synch2; &if -K 6; &save -a;
+&ps;
+
+&synch2; &if -K 6; &save -a;
+&ps;
+
+&synch2; &if -K 6; &save -a;
+&ps;
+
+&load;
+&ps;
+
+write_eqn output.eqn;
+
+&put;
+cec input.eqn output.eqn;


### PR DESCRIPTION
Adding the following ABC delay optimized scripts:

- abc_base6.d2.scr
- abc_base6.d3.scr

The QoR of [Yosys RS script](https://github.com/RapidSilicon/yosys_verific_rs/blob/main/scripts/synth/yosys/yosys_template_rs.ys) + `abc_base6.d2.scr` vs [Yosys RS script](https://github.com/RapidSilicon/yosys_verific_rs/blob/main/scripts/synth/yosys/yosys_template_rs.ys) + `abc_base6.a21.scr` is as following:	
<html>
<head>	

</head>

<body>


Metric | Average | Max | Min
-- | -- | -- | --
LUT | -27.09 | 0 | -170.1
Max Logic Level | 180.22 | 1357.14 | 0
Average Logic Lvel | 31.4 | 88.13 | -2.48


</body>

</html>

The QoR of [Yosys RS script](https://github.com/RapidSilicon/yosys_verific_rs/blob/main/scripts/synth/yosys/yosys_template_rs.ys) + `abc_base6.d3.scr` vs [Yosys RS script](https://github.com/RapidSilicon/yosys_verific_rs/blob/main/scripts/synth/yosys/yosys_template_rs.ys) + `abc_base6.a21.scr` is as following:	
<html>
<head>	

</head>

<body>


Metric | Average | Max | Min
-- | -- | -- | --
LUT | -22.4 | 2.3 | -157
Max Logic Level | 167.3 | 1357.1 | 0
Average Logic Lvel | 78.9 | 722.7 | -13.6


</body>

</html>


