### PR TITLE
Rolled back paths and names in All_lut suite

### DIFF
--- a/suites/All/All_lut_vivado.json
+++ b/suites/All/All_lut_vivado.json
@@ -56,9 +56,13 @@
             "top_module": "spi_top"
         },
         {
-            "name": "systemCdes",
-            "rtl_path": "RTL_Benchmark/Verilog/iwls2005_designs/systemCdes/rtl/verilog",
-            "top_module": "des_top"
+            "name": "systemcdes",
+            "rtl_path": "benchmarks/verilog/IWLS2005/systemcdes",
+            "top_module": "systemcdes",
+            "description": "For now keep the original version which is in yosys_verific_rs.",
+            "name_RTL_Benchmark": "systemCdes",
+            "rtl_path_RTL_Benchmark": "RTL_Benchmark/Verilog/iwls2005_designs/systemCdes/rtl/verilog",
+            "top_module_RTL_Benchmark": "des_top"
         },
         {
             "name": "usbf",
@@ -137,8 +141,12 @@
         },
         {
             "name": "iir",
-            "rtl_path": "RTL_Benchmark/Verilog/OpenCores_designs/iir/rtl",
-            "top_module": "iir_top"
+            "rtl_path": "benchmarks/verilog/ql_designs/iir",
+            "top_module": "top",
+            "description": "For now keep the original version which is in yosys_verific_rs.",
+            "name_RTL_Benchmark": "iir",
+            "rtl_path_RTL_Benchmark": "RTL_Benchmark/Verilog/OpenCores_designs/iir/rtl",
+            "top_module_RTL_Benchmark": "iir_top"
         },
         {
             "name": "io_max",


### PR DESCRIPTION
There were some differences of iir and systemcdes benchmarks in yosys_verific_rs and RTL_Benchmark repositories. This PR is intended for keeping existing All_lut suite consistent.