### PR TITLE
Added CI for yosys_verific_rs repository

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,10 +19,14 @@ jobs:
           mkdir -p "${{ github.workspace }}"
 
       - uses: actions/checkout@v2
+      
+      - name: Checkout submodules
+        run: |
+          git submodule update --init --recursive --progress
 
       - name: Build yosys+verific
         run:
-          make co_and_build_yosys_verific
+          make build_yosys_verific
 
       - name: Run tests
         run: |


### PR DESCRIPTION
The CI will perform the following:

- Checkout the yosys_verific_rs
- Update submodules
- Build Yosys+Verific
- Run yosys-rs-plugin unit tests.

Currently we don't specify to build all as LSOracle build is failing on Github runner. The #134 issue is created to fix the build failure.