### PR TITLE
Conditioning the generation of wrapper file

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,12 +29,12 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5.0.0
       with:
         python-version: 3.8
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install dependencies
       working-directory: ./.github/scripts
@@ -42,7 +42,7 @@ jobs:
         bash install_ubuntu_dependencies_build.sh
 
     - name: Use ccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2.12
       with:
         key: linux-${{ matrix.mode }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
 
 
-set(VERSION_PATCH 280)
+set(VERSION_PATCH 281)
 
 
 project(yosys_verific_rs)

--- a/design_edit/src/rs_design_edit.cc
+++ b/design_edit/src/rs_design_edit.cc
@@ -158,7 +158,7 @@ struct DesignEditRapidSilicon : public ScriptPass {
     return tokens;
   }
 
-  void processSdcFile(std::istream &input, std::ostream &output) {
+  void processSdcFile(std::istream &input) {
     std::string line;
     while (std::getline(input, line)) {
       std::vector<std::string> tokens = tokenizeString(line);
@@ -176,9 +176,6 @@ struct DesignEditRapidSilicon : public ScriptPass {
           location_map[tokens[2]]._name = tokens[2];
         }
       }
-    }
-    for (auto &p : location_map) {
-      p.second.print(output);
     }
   }
 
@@ -524,26 +521,12 @@ struct DesignEditRapidSilicon : public ScriptPass {
       }
       interface_mod->fixup_ports();
       if(sdc_passed) {
-        std::string new_sdc = "new_sdc.txt";
-        std::ofstream output_sdc(new_sdc);
         std::ifstream input_sdc(sdc_file);
         if (!input_sdc.is_open()) {
           std::cerr << "Error opening input sd file: " << sdc_file << std::endl;
         }
-        if (!output_sdc.is_open()) {
-          std::cerr << "Error opening output file: " << new_sdc << std::endl;
-          return;
-        }
-        processSdcFile(input_sdc, output_sdc);
+        processSdcFile(input_sdc);
         get_loc_map_by_io();
-        for (auto &p : location_map_by_io) {
-          std::cout << "Sig name: " << p.first << std::endl;
-          p.second.print(std::cout);
-        }
-
-        for(auto constraint : constrained_pins) {
-          std::cout << "PIN CONSTRAINED  " << constraint << std::endl;
-        }
       }
 
       dump_io_config_json(interface_mod, io_config_json);


### PR DESCRIPTION
Currently Wrapper file and config.json are being generated for all designs. We need to connect the wrapper with post_route netlist of VPR, so we are putting a condition to generate wrapper files only if IO primitives are present. If wrapper file is present we will write its content in the post rout netlist of VPR to get the whole design back.