### PR TITLE
Support more primitives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
 
 
-set(VERSION_PATCH 298)
+set(VERSION_PATCH 299)
 
 
 project(yosys_verific_rs)

--- a/design_edit/src/primitives_extractor.cc
+++ b/design_edit/src/primitives_extractor.cc
@@ -28,15 +28,19 @@
     c. CLK_BUF  [connected internally]
     d. I_DDR    [connected internally]
     e. O_DDR    [connected internally]
+    f. I_DELAY  [connected internally]
+    g. O_DELAY  [connected internally]
 
     and more when other use cases are understood
 
   Currently supported use cases are:
-    a. normal input port:  I_BUF
-    b. clock port:         I_BUF -> CLK_BUF
-    c. normal output port: O_BUF/O_BUFT
-    d. DDR input:          I_BUF -> I_DDR (become two bits)
-    e. DDR output:         (from two bits) O_DDR -> O_BUF
+    a. normal input port:   I_BUF
+    b. clock port:          I_BUF -> CLK_BUF
+    c. normal output port:  O_BUF/O_BUFT
+    d. DDR input:           I_BUF -> I_DDR (become two bits)
+    e. DDR output:          (from two bits) O_DDR -> O_BUF
+    f. I_DELAY:             I_BUF -> I_DELAY
+    g. O_DELAY:             O_DELAY -> O_BUF
 */
 /*
   Author: Chai, Chung Shien
@@ -147,10 +151,12 @@ const std::map<std::string, std::vector<PRIMITIVE_DB>> SUPPORTED_PRIMITIVES = {
     {"genesis3",
      // These are Port Primitive, they are directly connected to the
      // PIN/PORT/PAD
+     // Inputs
      {{PRIMITIVE_DB("\\I_BUF", true, true, IO_DIR::IN, {"\\I"}, {"\\O"}, "\\I",
                     "\\O")},
       {PRIMITIVE_DB("\\I_BUF_DS", false, true, IO_DIR::IN, {"\\I_P", "\\I_N"},
                     {"\\O"}, "", "\\O")},
+      // Output
       {PRIMITIVE_DB("\\O_BUF", true, true, IO_DIR::OUT, {"\\I"}, {"\\O"}, "\\O",
                     "\\I")},
       {PRIMITIVE_DB("\\O_BUFT", true, true, IO_DIR::OUT, {"\\I"}, {"\\O"},
@@ -160,10 +166,16 @@ const std::map<std::string, std::vector<PRIMITIVE_DB>> SUPPORTED_PRIMITIVES = {
       {PRIMITIVE_DB("\\O_BUFT_DS", false, true, IO_DIR::OUT, {"\\I"},
                     {"\\O_P", "\\O_N"}, "", "\\I")},
       // These are none-Port Primitive
+      // In direction
       {PRIMITIVE_DB("\\CLK_BUF", true, false, IO_DIR::IN, {"\\I"}, {"\\O"},
+                    "\\I", "\\O")},
+      {PRIMITIVE_DB("\\I_DELAY", true, false, IO_DIR::IN, {"\\I"}, {"\\O"},
                     "\\I", "\\O")},
       {PRIMITIVE_DB("\\I_DDR", true, false, IO_DIR::IN, {"\\D"}, {}, "\\D",
                     "")},
+      // Out direction
+      {PRIMITIVE_DB("\\O_DELAY", true, false, IO_DIR::OUT, {"\\I"}, {"\\O"},
+                    "\\O", "\\I")},
       {PRIMITIVE_DB("\\O_DDR", true, false, IO_DIR::OUT, {}, {"\\Q"}, "\\Q",
                     "")}}}};
 
@@ -327,13 +339,19 @@ bool PRIMITIVES_EXTRACTOR::extract(RTLIL::Design* design) {
   // Step 3: Trace CLK_BUF connection
   trace_none_port_primitive(design->top_module(), "\\I_BUF", "\\CLK_BUF");
 
-  // Step 4: Trace I_DDR connection
+  // Step 5: Trace I_DELAY connection
+  trace_none_port_primitive(design->top_module(), "\\I_BUF", "\\I_DELAY");
+
+  // Step 6: Trace I_DDR connection
   trace_none_port_primitive(design->top_module(), "\\I_BUF", "\\I_DDR");
 
-  // Step 5: Trace O_DDR connection
+  // Step 7: Trace O_DELAY connection
+  trace_none_port_primitive(design->top_module(), "\\O_BUF", "\\O_DELAY");
+
+  // Step 8: Trace O_DDR connection
   trace_none_port_primitive(design->top_module(), "\\O_BUF", "\\O_DDR");
 
-  // Step 6: Support more primitive once more use cases are understood
+  // Step 9: Support more primitive once more use cases are understood
 
   // Lastly generate instance(s)
   if (m_status) {

--- a/design_edit/src/primitives_extractor.cc
+++ b/design_edit/src/primitives_extractor.cc
@@ -38,7 +38,9 @@
     b. clock port:          I_BUF -> CLK_BUF
     c. normal output port:  O_BUF/O_BUFT
     d. DDR input:           I_BUF -> I_DDR (become two bits)
+                            I_DELAY -> I_DDR (become two bits)
     e. DDR output:          (from two bits) O_DDR -> O_BUF
+                            (become two bits) O_DDR --> O_DELAY
     f. I_DELAY:             I_BUF -> I_DELAY
     g. O_DELAY:             O_DELAY -> O_BUF
 */

--- a/design_edit/src/primitives_extractor.cc
+++ b/design_edit/src/primitives_extractor.cc
@@ -327,7 +327,7 @@ bool PRIMITIVES_EXTRACTOR::extract(RTLIL::Design* design) {
   // Step 3: Trace CLK_BUF connection
   trace_none_port_primitive(design->top_module(), "\\I_BUF", "\\CLK_BUF");
 
-  // Step 5: Trace I_DDR connection
+  // Step 4: Trace I_DDR connection
   trace_none_port_primitive(design->top_module(), "\\I_BUF", "\\I_DDR");
 
   // Step 5: Trace O_DDR connection

--- a/design_edit/src/primitives_extractor.h
+++ b/design_edit/src/primitives_extractor.h
@@ -71,9 +71,9 @@ class PRIMITIVES_EXTRACTOR {
   std::map<std::string, std::string> is_connected_cell(
       Yosys::RTLIL::Cell* cell, const PRIMITIVE_DB* db,
       const std::string& connection);
-  void trace_none_port_primitive(Yosys::RTLIL::Module* module,
-                                 const std::string& port_primitive_name,
-                                 const std::string& none_port_primitive_name);
+  void trace_next_primitive(Yosys::RTLIL::Module* module,
+                            const std::string& src_primitive_name,
+                            const std::string& dest_primitive_name);
   bool trace_next_primitive(Yosys::RTLIL::Module* module,
                             const std::string& module_name, PRIMITIVE*& parent,
                             const std::string& connection);
@@ -82,9 +82,14 @@ class PRIMITIVES_EXTRACTOR {
   void get_signals(const Yosys::RTLIL::SigSpec& sig,
                    std::vector<std::string>& signals);
   void gen_instances();
+  void gen_instances(const std::string& linked_object,
+                     std::vector<std::string> linked_objects,
+                     const PRIMITIVE* primitive);
   void gen_instance(std::vector<std::string> linked_objects,
                     const PRIMITIVE* primitive);
-  void gen_wire(const PORT_PRIMITIVE* port, const std::string& child);
+  void gen_wire(const std::string& linked_object,
+                std::vector<std::string> linked_objects, const PRIMITIVE* port,
+                const std::string& child);
   void write_instance(const INSTANCE* instance, std::ofstream& json);
   void write_instance_map(std::map<std::string, std::string> map,
                           std::ofstream& json, uint32_t space = 4);
@@ -98,6 +103,7 @@ class PRIMITIVES_EXTRACTOR {
   std::vector<MSG*> m_msgs;
   std::vector<PORT_PRIMITIVE*> m_ports;
   std::vector<PRIMITIVE*> m_child_primitives;
+  std::vector<PRIMITIVE*> m_all_primitives;
   std::vector<INSTANCE*> m_instances;
   bool m_status = true;
   const std::string m_technology = "";

--- a/design_edit/src/primitives_extractor.h
+++ b/design_edit/src/primitives_extractor.h
@@ -55,7 +55,7 @@ class PRIMITIVES_EXTRACTOR {
   const PRIMITIVE_DB* is_supported_primitive(const std::string& name,
                                              PORT_REQ req);
   void get_primitive_parameters(Yosys::RTLIL::Cell* cell, PRIMITIVE* primitive);
-  bool trace_and_create_port(Yosys::RTLIL::Module* module,
+  void trace_and_create_port(Yosys::RTLIL::Module* module,
                              std::vector<PORT_INFO>& port_infos);
   bool get_connected_port(Yosys::RTLIL::Module* module,
                           const std::string& cell_port_name,
@@ -63,7 +63,7 @@ class PRIMITIVES_EXTRACTOR {
                           std::vector<PORT_INFO>& port_infos,
                           std::vector<size_t>& port_trackers,
                           std::vector<PORT_INFO>& connected_ports,
-                          int loop=0);
+                          int loop = 0);
   bool get_port_cell_connections(
       Yosys::RTLIL::Cell* cell, const PRIMITIVE_DB* db,
       std::map<std::string, std::string>& primary_connections,
@@ -71,7 +71,9 @@ class PRIMITIVES_EXTRACTOR {
   std::map<std::string, std::string> is_connected_cell(
       Yosys::RTLIL::Cell* cell, const PRIMITIVE_DB* db,
       const std::string& connection);
-  void trace_clk_buf(Yosys::RTLIL::Module* module);
+  void trace_none_port_primitive(Yosys::RTLIL::Module* module,
+                                 const std::string& port_primitive_name,
+                                 const std::string& none_port_primitive_name);
   bool trace_next_primitive(Yosys::RTLIL::Module* module,
                             const std::string& module_name, PRIMITIVE*& parent,
                             const std::string& connection);


### PR DESCRIPTION
Add more primitives support:
   - O_BUFT
   - I_DDR
   - O_DDR
   - I_DELAY
   - O_DELAY

More support to come. Example: I_SERDES, O_SERDES, PLL etc 

This PR must merge into Raptor together with https://github.com/os-fpga/FOEDAG/pull/1530, otherwise Raptor will fail if the design contains primitives that does not have I and O naming. 