### PR TITLE
Support more use cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
 
 
-set(VERSION_PATCH 300)
+set(VERSION_PATCH 301)
 
 
 project(yosys_verific_rs)


### PR DESCRIPTION
Support more use cases.

Also can new infra feature where we could support special case for PLL. Previously for all the other primitives we supported so far, the ALL important ports need to be connected. Otherwise extractor will treat it as illegal. 
   - This is not the true for PLL. 
   - For PLL, the important ports are:  CLK_IN, CLK_OUT, CLK_OUT_DIV2, CLK_OUT_DIV3 and CLK_OUT_DIV4. 
   - But not all the **_outputs_** above need to be connected. 
   - New infra support new feature which is table-driven, if newly added boolean is set TRUE, extractor will still treat the connectivity as legal, as long as one of the port is connected. 