### PR TITLE
Prepare to support route clock to gearbox

### DIFF
--- a/design_edit/src/primitives_extractor.h
+++ b/design_edit/src/primitives_extractor.h
@@ -78,6 +78,7 @@ class PRIMITIVES_EXTRACTOR {
   bool trace_next_primitive(Yosys::RTLIL::Module* module,
                             const std::string& module_name, PRIMITIVE*& parent,
                             const std::string& connection);
+  void trace_gearbox_clock();
   void get_chunks(const Yosys::RTLIL::SigChunk& chunk,
                   std::vector<std::string>& signals);
   void get_signals(const Yosys::RTLIL::SigSpec& sig,
@@ -85,9 +86,11 @@ class PRIMITIVES_EXTRACTOR {
   void gen_instances();
   void gen_instances(const std::string& linked_object,
                      std::vector<std::string> linked_objects,
-                     const PRIMITIVE* primitive);
+                     const PRIMITIVE* primitive,
+                     const std::string& pre_primitive);
   void gen_instance(std::vector<std::string> linked_objects,
-                    const PRIMITIVE* primitive);
+                    const PRIMITIVE* primitive,
+                    const std::string& pre_primitive);
   void gen_wire(const std::string& linked_object,
                 std::vector<std::string> linked_objects, const PRIMITIVE* port,
                 const std::string& child);


### PR DESCRIPTION
Currently we already support:
   - routing clock from pin to fabric
   - routing clock ftom pin to pll ref
   - routing clock from pll to fabric

This is to generating more information on the json, to prepare support of routing clock to gearbox. 

Testing: 
   - ported code to latest NS Raptor manually
   - run batch, batch_gen2 and batch_gen3 test. 