### PR TITLE
Support core_clk and fabric clk routing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
 
 
-set(VERSION_PATCH 311)
+set(VERSION_PATCH 312)
 
 
 project(yosys_verific_rs)

--- a/design_edit/src/primitives_extractor.h
+++ b/design_edit/src/primitives_extractor.h
@@ -94,7 +94,11 @@ class PRIMITIVES_EXTRACTOR {
   void gen_wire(const std::string& linked_object,
                 std::vector<std::string> linked_objects, const PRIMITIVE* port,
                 const std::string& child);
-  void determine_fabric_clock();
+  void determine_fabric_clock(Yosys::RTLIL::Module* module);
+  bool need_to_route_to_fabric(Yosys::RTLIL::Module* module,
+                               const std::string& module_type,
+                               const std::string& module_name,
+                               const std::string& net_name);
   void summarize();
   void summarize(const PRIMITIVE* primitive,
                  const std::vector<std::string> traces, bool is_in_dir);


### PR DESCRIPTION
Initial support:
   - Record core_clk port information in the database.
   - Only route fabric clk routing when it is needed (original support is always route)

Simplify code with more database driven - in determine the fabric clk routing. 

Testing:
   - ported code to latest NS Raptor manually
   - run batch, batch_gen2 and batch_gen3 test. (Note: and2_bitstream had been failing locally)
