### PR TITLE
Generate two config JSONs

### DIFF
--- a/design_edit/src/rs_design_edit.cc
+++ b/design_edit/src/rs_design_edit.cc
@@ -225,18 +225,18 @@ struct DesignEditRapidSilicon : public ScriptPass {
     } 
     // Recursively marks other primitives
     while (true) {
-      size_t connected = 0;
+      size_t linked = 0;
       for (auto& inst : instances_array) {
         if (inst.contains("linked_object")) {
           for (auto& iter : inst["connectivity"].items()) {
             if (std::find(CONNECTING_PORTS.begin(), CONNECTING_PORTS.end(), (std::string)(iter.key())) != 
                 CONNECTING_PORTS.end()) {
-              connected += mark_instance_object(instances_array, inst["linked_object"], (std::string)(iter.value()));
+              linked += link_instance(instances_array, inst["linked_object"], (std::string)(iter.value()));
             }
           }
         }
       }
-      if (connected == 0) {
+      if (linked == 0) {
         // until we cannot mark anymore
         break;
       }
@@ -248,10 +248,10 @@ struct DesignEditRapidSilicon : public ScriptPass {
     }
   }
   
-  size_t mark_instance_object(json& instances_array, const std::string& object, const std::string& net) {
-    size_t marked = 0;
+  size_t link_instance(json& instances_array, const std::string& object, const std::string& net) {
+    size_t linked = 0;
     for (auto& inst : instances_array) {
-      // If this instance had not been marked
+      // Only if this instance had not been linked
       if (!inst.contains("linked_object")) {
         for (auto& iter : inst["connectivity"].items()) {
           if (std::find(CONNECTING_PORTS.begin(), CONNECTING_PORTS.end(), (std::string)(iter.key())) != 
@@ -259,14 +259,14 @@ struct DesignEditRapidSilicon : public ScriptPass {
               (inst["module"] == "PLL" && (std::string)(iter.key()) == "CLK_IN")) {
             if ((std::string)(iter.value()) == net) {
               inst["linked_object"] = object;
-              marked++;
+              linked++;
               break;
             }
           }
         }
       }
     }
-    return marked;
+    return linked;
   }
 
   std::string remove_backslashes(const std::string &input) {

--- a/design_edit/src/rs_design_edit.cc
+++ b/design_edit/src/rs_design_edit.cc
@@ -248,8 +248,8 @@ struct DesignEditRapidSilicon : public ScriptPass {
     // Special case for I_BUF_DS and O_BUF_DS, O_BUFT_DS, because they have multiple objects
     // We need to loop this recursive loop twice
     for (i = 0; i < 2; i++) {
-      // first time: only link I_BUF_DS and O_BUF_DS, O_BUFT_DS (before they are used to link for instance)
-      //             you will find these primitives have special name
+      // first time : only link I_BUF_DS and O_BUF_DS, O_BUFT_DS (before they are used to link other instance)
+      //              because the name needs to be "p+n"
       // second time: link the rest
       while (true) {
         // Recursively marks other primitives
@@ -271,7 +271,8 @@ struct DesignEditRapidSilicon : public ScriptPass {
           }
         }
         if (i == 0 || linked == 0) {
-          // until we cannot mark anymore
+          // 1st time: we do not need recursive loop. One time is enough
+          // 2nd time: we need recursive until we cannot link anymore
           break;
         }
       }

--- a/design_edit/src/rs_design_edit.cc
+++ b/design_edit/src/rs_design_edit.cc
@@ -180,7 +180,7 @@ struct DesignEditRapidSilicon : public ScriptPass {
             if(wire != NULL)
             {
               connection = process_connection(*it);
-                    break;
+              break;
             }
           }
         }

--- a/design_edit/src/rs_design_edit.cc
+++ b/design_edit/src/rs_design_edit.cc
@@ -207,8 +207,8 @@ struct DesignEditRapidSilicon : public ScriptPass {
       json instance_object;
       instance_object["module"] = (std::string)("WIRE");
       instance_object["name"] = (std::string)(stringf("WIRE_%ld", i));
-      instance_object["connectivity"]["I"] = right.str();
-      instance_object["connectivity"]["O"] = left.str();
+      instance_object["connectivity"]["I"] = remove_backslashes(right.str());
+      instance_object["connectivity"]["O"] = remove_backslashes(left.str());
       instances_array.push_back(instance_object);
       i++;
     }

--- a/design_edit/src/rs_design_edit.cc
+++ b/design_edit/src/rs_design_edit.cc
@@ -208,7 +208,7 @@ struct DesignEditRapidSilicon : public ScriptPass {
       RTLIL_BACKEND::dump_sigspec(right, it.second, true, true);
       json instance_object;
       instance_object["module"] = (std::string)("WIRE");
-      instance_object["name"] = (std::string)(stringf("WIRE_%ld", i));
+      instance_object["name"] = (std::string)(stringf("wire%ld", i));
       instance_object["connectivity"]["I"] = remove_backslashes(right.str());
       instance_object["connectivity"]["O"] = remove_backslashes(left.str());
       instances_array.push_back(instance_object);


### PR DESCRIPTION
Changes:
   - Generate two json: config.json and io_config.json
   - io_config.json used by IO bitstream generation (from original design, by extractor)
   - config.json used by other flow (from wrapped design, by editor)
   - in the future, will need to fix discrepency seen in original vs wrapped design, then all flow should use a single JSON
   - Improve existing editor JSON generator: Generate wire instance, link related instances. 

Testing:
   - Not tested
   - Downloading latest NS Raptor for batch test