### PR TITLE
Make sure no link using empty string net

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
 
 
-set(VERSION_PATCH 316)
+set(VERSION_PATCH 317)
 
 
 project(yosys_verific_rs)

--- a/design_edit/src/rs_design_edit.cc
+++ b/design_edit/src/rs_design_edit.cc
@@ -276,6 +276,9 @@ struct DesignEditRapidSilicon : public ScriptPass {
                   log_assert(signals.is_array());
                 }
                 for (auto& s : signals) {
+                  if ((std::string)(s) == "") {
+                    continue;
+                  }
                   if (i == 0) {
                     linked += link_instance(instances_array, inst["linked_object"], (std::string)(s), 
                                             inst["direction"], uint32_t(inst["index"]) + 1, true, 
@@ -316,6 +319,9 @@ struct DesignEditRapidSilicon : public ScriptPass {
       if (!inst.contains("linked_object") || allow_dual_name) {
         for (auto& iter : inst["connectivity"].items()) {
           if (!iter.value().is_string()) {
+            continue;
+          }
+          if ((std::string)(iter.key()) == "") {
             continue;
           }
           if (std::find(CONNECTING_PORTS.begin(), CONNECTING_PORTS.end(), (std::string)(iter.key())) != 


### PR DESCRIPTION
This is the misc improvement to make sure we do not link primitives using empty string net. 

This maybe happen if user does not connect data path ports. Example 
   - one primitive O-port is unconnected (maybe have empty string - but if the connection does not exists in the first place in the cell, then that is ok).
   - another primitive I-port is unconncetd as well (maybe have empty string). 
   - If we allow empty string as a net to search the connection, we might end up linking these two primitives. 