### PR TITLE
Add support to O_SERDES_CLK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
 
 
-set(VERSION_PATCH 318)
+set(VERSION_PATCH 319)
 
 
 project(yosys_verific_rs)

--- a/design_edit/src/primitives_extractor.h
+++ b/design_edit/src/primitives_extractor.h
@@ -98,6 +98,7 @@ class PRIMITIVES_EXTRACTOR {
   bool need_to_route_to_fabric(Yosys::RTLIL::Module* module,
                                const std::string& module_type,
                                const std::string& module_name,
+                               const std::string& port_name,
                                const std::string& net_name);
   void summarize();
   void summarize(const PRIMITIVE* primitive,


### PR DESCRIPTION
Add O_SERDES_CLK primitive. This primitive is used to route internal fast_clk to the output.

No functionality changes:
   - Add O_SERDES_CLK into data-driven table
   - Add O_SERDES_CLK valid connection map
   - Add more debug message for fabric clock

Testing:
   - ported code to latest NS Raptor manually
   - run batch, batch_gen2 (no run on batch_gen3)