### PR TITLE
Improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
 
 
-set(VERSION_PATCH 319)
+set(VERSION_PATCH 320)
 
 
 project(yosys_verific_rs)


### PR DESCRIPTION
No algorithm functional change. Two improvement:
1. On io_config.json
   - Log any detected error in the json file
   - For const signal, previously the PRIMITIVES_EXTRACTOR::get_signals() will print empty string. Now it will print `__const_bit_{value}__` 
2. On config.json
   - Handle net connection searching accordingly since PRIMITIVES_EXTRACTOR::get_signals() had been improvement (no longer just empty string)

Testing:
   - ported code to latest NS Raptor manually
   - run batch, batch_gen2 (no run on batch_gen3)