### PR TITLE
Enhance design editor generated SDC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
 
 
-set(VERSION_PATCH 320)
+set(VERSION_PATCH 321)
 
 
 project(yosys_verific_rs)

--- a/design_edit/src/primitives_extractor.cc
+++ b/design_edit/src/primitives_extractor.cc
@@ -1642,7 +1642,7 @@ void PRIMITIVES_EXTRACTOR::update_pin_info(PIN_PORT*& pin,
           if (primitive->db->name == "\\CLK_BUF") {
             pin->skip_reason = "The clock is not used by fabric.";
           } else {
-            pin->skip_reason = "The clock is not controllable by fabric";
+            pin->skip_reason = "The clock is Gearbox internal fast clock.";
           }
         }
         break;

--- a/design_edit/src/primitives_extractor.h
+++ b/design_edit/src/primitives_extractor.h
@@ -37,6 +37,7 @@ struct PRIMITIVE_DB;
 struct PRIMITIVE;
 struct PORT_PRIMITIVE;
 struct INSTANCE;
+struct PIN_PORT;
 
 class PRIMITIVES_EXTRACTOR {
  public:
@@ -104,7 +105,12 @@ class PRIMITIVES_EXTRACTOR {
   void summarize(const PRIMITIVE* primitive,
                  const std::vector<std::string> traces, bool is_in_dir);
   void summarize(const PRIMITIVE* primitive, const std::string& object_name,
-                 const std::vector<std::string> traces, bool is_in_dir);
+                 const std::vector<std::string> objects,
+                 const std::vector<std::string> traces,
+                 const std::vector<std::string> full_traces, bool is_in_dir);
+  void update_pin_info(PIN_PORT*& pin, const PRIMITIVE* primitive);
+  void update_pin_traces(std::vector<std::string>& pin_traces,
+                         const std::vector<std::string> traces, bool is_in_dir);
   void finalize(Yosys::RTLIL::Module* module);
   void write_instance(const INSTANCE* instance, std::ofstream& json,
                       bool simple);
@@ -126,7 +132,9 @@ class PRIMITIVES_EXTRACTOR {
   std::vector<std::string> fabric_clocks;
   int max_in_object_name = 0;
   int max_out_object_name = 0;
+  int max_object_name = 0;
   int max_trace = 0;
+  std::map<std::string, PIN_PORT*> m_pin_infos;
 };
 
 #endif

--- a/design_edit/src/rs_design_edit.cc
+++ b/design_edit/src/rs_design_edit.cc
@@ -1227,11 +1227,6 @@ struct DesignEditRapidSilicon : public ScriptPass {
       interface_mod->remove({wire});
     }
     
-    delete_wires(original_mod, orig_intermediate_wires);
-    fixup_mod_ports(original_mod);
-    Pass::call(_design, "clean");
-    delete_wires(interface_mod, interface_intermediate_wires);
-    interface_mod->fixup_ports();
     if(sdc_passed) {
       std::ifstream input_sdc(sdc_file);
       if (!input_sdc.is_open()) {
@@ -1255,6 +1250,14 @@ struct DesignEditRapidSilicon : public ScriptPass {
       extractor.write_json("io_config.simple.json", true);
     }
     extractor.write_sdc("design_edit.sdc");
+    
+    // Should only clean the _design after extractor done the work
+    // because extractor is using _design
+    delete_wires(original_mod, orig_intermediate_wires);
+    fixup_mod_ports(original_mod);
+    Pass::call(_design, "clean");
+    delete_wires(interface_mod, interface_intermediate_wires);
+    interface_mod->fixup_ports();
 
     for (auto cell : wrapper_mod->cells()) {
       string module_name = cell->type.str();


### PR DESCRIPTION
Existing extractor already have information about if a clock need to be routed to fabric
Exisitng extractor already generate SDC file which contains set_clock_pin command

This PR
1. Use the "clock-to-fabric routing" information to filter pin/mode assignment from user.
2. If the clock is not needed by fabric, extractor will commet it out in design_editor version of SDC
3. Enhance the code to auto-determine "mode" based on primitive connectivity
4. In summary: now extractor will **_ALWAYS_** generate 3 information of all port 
   - set_clock_pin 
   - set_mode
   - set_io

Testing:
   - ported code to latest NS Raptor manually (with https://github.com/os-fpga/FOEDAG/pull/1592)
   - run batch, batch_gen2 (no run on batch_gen3)