### PR TITLE
Do not need to different pin or internal signal when generate SDC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
 
 
-set(VERSION_PATCH 327)
+set(VERSION_PATCH 328)
 
 
 project(yosys_verific_rs)

--- a/design_edit/src/primitives_extractor.h
+++ b/design_edit/src/primitives_extractor.h
@@ -46,19 +46,17 @@ struct PIN_PORT;
 */
 struct FABRIC_CLOCK {
   FABRIC_CLOCK(const std::string& l, const std::string& m, const std::string& i,
-               const std::string& p, const std::string& n, bool c)
+               const std::string& p, const std::string& n)
       : linked_object(l),
         module(m),
         name(i),
         port(p),
-        net(n),
-        is_clock_pin(c) {}
+        net(n) {}
   const std::string linked_object = "";
   const std::string module = "";
   const std::string name = "";
   const std::string port = "";
   const std::string net = "";
-  const bool is_clock_pin = false;
 };
 
 class PRIMITIVES_EXTRACTOR {


### PR DESCRIPTION
Simplify the flow: do not need to different if the clock is from pin or internal signal when generating SDC.

The final flow will now always map the name to fabric_ module (wrapped design)

This change basically only remove code.