### PR TITLE
Support Fabric Clock Buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
 
 
-set(VERSION_PATCH 330)
+set(VERSION_PATCH 331)
 
 
 project(yosys_verific_rs)

--- a/design_edit/src/primitives_extractor.cc
+++ b/design_edit/src/primitives_extractor.cc
@@ -689,8 +689,8 @@ bool PRIMITIVES_EXTRACTOR::extract(RTLIL::Design* design) {
 
   // Step 9: Support more primitive once more use cases are understood
 
-  // Step 10: Let's make fabric clock buffer as the last item to trace (need to add
-  // to the chain)
+  // Step 10: Let's make fabric clock buffer as the last item to trace (need to
+  // add to the chain)
   trace_fabric_clkbuf(design->top_module());
 
   // Step 11: Trace primitive that the clock need to routed to gearbox (does not

--- a/design_edit/src/rs_design_edit.cc
+++ b/design_edit/src/rs_design_edit.cc
@@ -158,16 +158,6 @@ struct DesignEditRapidSilicon : public ScriptPass {
     }
     return output.str();
   }
-  
-  bool is_real_net(const std::string& net) {
-    if (net == "" || 
-        ((net.size() > 14) && 
-         (net.find("__const_bit_") == 0) && 
-         (net.rfind("__") == (net.size() - 2)))) {
-      return false;
-    }
-    return true;
-  }
 
   void dump_io_config_json(Module* mod, std::string file) {
     std::ofstream json_file(file.c_str());
@@ -298,7 +288,7 @@ struct DesignEditRapidSilicon : public ScriptPass {
                 }
                 for (auto& s : signals) {
                   std::string net = (std::string)(s);
-                  if (!is_real_net(net)) {
+                  if (!PRIMITIVES_EXTRACTOR::is_real_net(net)) {
                     continue;
                   }
                   if (i == 0) {
@@ -345,7 +335,7 @@ struct DesignEditRapidSilicon : public ScriptPass {
             continue;
           }
           std::string inst_net = (std::string)(iter.value());
-          if (!is_real_net(inst_net)) {
+          if (!PRIMITIVES_EXTRACTOR::is_real_net(inst_net)) {
             continue;
           }
           bool match = false;


### PR DESCRIPTION
This is to support newly added peripheral primitive - FCLK_BUF (see https://rapidsilicon.atlassian.net/browse/EDA-2904)

Additional checking to make sure 
 - "I" port of FCLK_BUF must be connected to non-io-primitive (fabric)
 - "O" port of FCLK_BUF must be connected to non-io-primitive (fabric)

New SDC command will be printed into design_edit.sdc if FCLK_BUF is being used
 - The command is called "set_clock_out"
 - This is to tell OpenFPGA the generated fabric clock need to be routed to which slot of Gearbox subsystsem (seems currently not supported due to RTL bug)
 - This information will be used in FOEDAG eventually
 - This command is very similar to existing "set_clock_pin" command. 
   - set_clock_out to tell which slot to route clock from fabric to outside world (Gearbox subsystem)
   - set_clock_pin to tell which slot to route clock from outside world (Gearbox subsystem) to fabric

Testing done:
- Port this PR to latest NS Raptor
- Run test/batch, test/batch_gen2. test/batch_gen3 and /up5bit_counter_dual_clock_bitstream