### PR TITLE
EDA-2762 - Support data from second half of gearbox

### DIFF
--- a/design_edit/src/primitives_extractor.cc
+++ b/design_edit/src/primitives_extractor.cc
@@ -1970,12 +1970,12 @@ void PRIMITIVES_EXTRACTOR::update_pin_info(const std::string& pin_name,
         if (instance->parameters.find("ROUTE_TO_FABRIC_CLK") ==
             instance->parameters.end()) {
           if (primitive->db->name == "\\CLK_BUF") {
-            pin->skip_reason = "The clock is not used by fabric.";
+            pin->skip_reason = "The clock is not used by fabric";
           } else {
-            pin->skip_reason = "The clock is Gearbox internal fast clock.";
+            pin->skip_reason = "The clock is Gearbox internal fast clock";
           }
         } else {
-          pin->skip_reason = "Temporarily disable all clock constraint.";
+          pin->skip_reason = "Temporarily disable all clock constraint";
         }
         break;
       }
@@ -1994,7 +1994,7 @@ void PRIMITIVES_EXTRACTOR::update_pin_info(const std::string& pin_name,
       pin->skip_reason =
           "This is secondary pin. But IO bitstream generation will still make "
           "sure it is used in pair. Otherwise the IO bitstream will be "
-          "invalid.";
+          "invalid";
     }
   }
 }
@@ -2396,89 +2396,69 @@ void PRIMITIVES_EXTRACTOR::write_sdc(const std::string& file,
       }
       i++;
     }
-    std::string location = "__NOT_PROVIDED__";
-    char ab = '?';
-    if (pin->location.size()) {
-      if (pin->location.back() == 'P') {
-        location = pin->location;
-        ab = 'A';
-      } else if (pin->location.back() == 'N') {
-        location = pin->location;
-        ab = 'B';
-      } else {
-        location = stringf("__INVALID::%s__", pin->location.c_str());
+    PIN_PARSER parsed_pin;
+    POST_MSG(3, "Pin object=%s, location: %s", pin->name.c_str(),
+             pin->location.c_str());
+    if (validate_location(pin->location, parsed_pin)) {
+      char ab = pin->location.back() == 'P' ? 'A' : 'B';
+      std::string mode = "MODE_BP_DIR";
+      if (pin->mode == "SDR") {
+        mode = "MODE_BP_SDR";
+      } else if (pin->mode == "DDR") {
+        mode = "MODE_BP_DDR";
+      } else if (pin->mode.find("RATE_") == 0) {
+        mode = stringf("MODE_%s", pin->mode.c_str());
       }
-    }
-    std::string mode = "MODE_BP_DIR";
-    if (pin->mode == "SDR") {
-      mode = "MODE_BP_SDR";
-    } else if (pin->mode == "DDR") {
-      mode = "MODE_BP_DDR";
-    } else if (pin->mode.find("RATE_") == 0) {
-      mode = stringf("MODE_%s", pin->mode.c_str());
-    }
-    mode = stringf("%s_%c_%s", mode.c_str(), ab, pin->is_input ? "RX" : "TX");
-    std::string object = stringf("%s", pin->name.c_str());
-    int alignment = int(object.size());
-    if (int(mode.size()) > alignment) {
-      alignment = int(mode.size());
-    }
-    if (pin->skip_reason.size()) {
-      entry.comments.push_back(
-          stringf("# Skip this because \'%s\'", pin->skip_reason.c_str()));
-    }
-    std::string skip = "";
-    std::string data_reason = "";
-    std::vector<std::string> data_nets;
-    std::vector<bool> found_data_nets;
-    bool data_input = false;
-    if (ab == '?' || pin->skip_reason.size() > 0) {
-      skip = "# ";
-    } else {
-      data_reason = get_fabric_data(wrapped_instances, object, data_nets,
-                                    found_data_nets, data_input);
-      if (data_reason.size()) {
-        if (data_reason.find("but data signal is not defined") ==
-            std::string::npos) {
-          entry.comments.push_back(
-              stringf("# Failure reason: %s", data_reason.c_str()));
+      mode = stringf("%s_%c_%s", mode.c_str(), ab, pin->is_input ? "RX" : "TX");
+      if (m_location_mode.find(pin->location) == m_location_mode.end()) {
+        m_location_mode[pin->location] = mode;
+      }
+      if (pin->skip_reason.size()) {
+        POST_MSG(4, "Skip this because \'%s\'", pin->skip_reason.c_str());
+        entry.comments.push_back(
+            stringf("# Skip this because \'%s\'", pin->skip_reason.c_str()));
+      } else {
+        std::vector<std::string> data_nets;
+        std::vector<bool> found_data_nets;
+        bool data_input = false;
+        std::string data_reason =
+            get_fabric_data(wrapped_instances, pin->name, data_nets,
+                            found_data_nets, data_input);
+        if (data_reason.size()) {
+          if (data_reason.find("but data signal is not defined") ==
+              std::string::npos) {
+            entry.comments.push_back(
+                stringf("# Failure reason: %s", data_reason.c_str()));
+          } else {
+            entry.comments.push_back(stringf("# %s", data_reason.c_str()));
+          }
         } else {
-          entry.comments.push_back(stringf("# %s", data_reason.c_str()));
+          entry.assignments.push_back(
+              SDC_ASSIGNMENT("# set_mode", mode, pin->location, ""));
+          entry.assignments.push_back(SDC_ASSIGNMENT(
+              "# set_io", pin->name, pin->location, "--> (original)"));
+          std::string location =
+              ab == 'A' ? pin->location
+                        : stringf("H%s_%s%s_%d_%dP", parsed_pin.type.c_str(),
+                                  parsed_pin.bank.c_str(),
+                                  parsed_pin.is_clock ? "_CC" : "",
+                                  parsed_pin.index - 1, parsed_pin.index / 2);
+          for (size_t data_i = 0, data_j = (ab == 'A' ? 0 : 5);
+               data_i < data_nets.size(); data_i++, data_j++) {
+            entry.assignments.push_back(SDC_ASSIGNMENT(
+                (std::string)(found_data_nets[data_i] ? "" : "# ") + "set_io",
+                data_nets[data_i], location, "-mode", mode, "-internal_pin",
+                stringf("%s[%ld]_A", data_input ? "g2f_rx_in" : "f2g_tx_out",
+                        data_j)));
+          }
         }
       }
-    }
-    // Mode
-    if (ab == '?') {
-      entry.assignments.push_back(
-          SDC_ASSIGNMENT("# set_mode", mode, location, ""));
+    } else if (pin->location.size()) {
+      POST_MSG(4, "Pin location is invalid");
+      entry.comments.push_back("# Pin location is invalid");
     } else {
-      entry.assignments.push_back(
-          SDC_ASSIGNMENT("set_mode", mode, location, ""));
-      if (m_location_mode.find(location) == m_location_mode.end()) {
-        m_location_mode[location] = mode;
-      }
-    }
-    // IO
-    if (data_reason.empty() && data_nets.size() > 0 &&
-        data_nets.size() == found_data_nets.size()) {
-      if (pin->internal_pin.size()) {
-        entry.assignments.push_back(
-            SDC_ASSIGNMENT("# set_io", object, location,
-                           pin->internal_pin + std::string(" --> (original)")));
-      } else {
-        entry.assignments.push_back(
-            SDC_ASSIGNMENT("# set_io", object, location, "--> (original)"));
-      }
-      for (size_t data_i = 0; data_i < data_nets.size(); data_i++) {
-        entry.assignments.push_back(SDC_ASSIGNMENT(
-            (std::string)(found_data_nets[data_i] ? "" : "# ") + "set_io",
-            data_nets[data_i], location,
-            stringf("%s[%ld]_%c", data_input ? "g2f_rx_in" : "f2g_tx_out",
-                    data_i, ab)));
-      }
-    } else {
-      entry.assignments.push_back(
-          SDC_ASSIGNMENT(skip + "set_io", object, location, pin->internal_pin));
+      POST_MSG(4, "Pin location is not assigned");
+      entry.comments.push_back("# Pin location is not assigned");
     }
     sdc_entries.push_back(entry);
   }
@@ -2541,9 +2521,11 @@ void PRIMITIVES_EXTRACTOR::write_sdc_internal_control_signal(
   entry.comments.push_back(stringf("# Port: %s", port.c_str()));
   entry.comments.push_back(stringf("# Signal: %s", internal_signal.c_str()));
 #endif
-  PIN_PARSER pin;
-  bool location_status = validate_location(location, pin);
-  if (location_status) {
+  // If the mode is available, then the location had been parsed correctly in
+  // the first place
+  if (m_location_mode.find(location) != m_location_mode.end()) {
+    PIN_PARSER pin;
+    log_assert(validate_location(location, pin));
     std::vector<std::string> wrapped_nets;
     std::string reason = get_wrapped_instance_net_by_port(
         wrapped_instances, module, linked_object, port, wrapped_nets);
@@ -2640,23 +2622,17 @@ void PRIMITIVES_EXTRACTOR::write_sdc_internal_control_signal(
                 skip = "# ";
               }
             }
-            if (skip == "" &&
-                m_location_mode.find(assigned_location) ==
-                    m_location_mode.end() &&
-                m_location_mode.find(location) != m_location_mode.end()) {
-              entry.assignments.push_back(
-                  SDC_ASSIGNMENT("set_mode", m_location_mode[location],
-                                 assigned_location, ""));
-            }
             std::string set_io = stringf("%sset_io", skip.c_str());
-            entry.assignments.push_back(SDC_ASSIGNMENT(
-                set_io, wrapped_net, assigned_location, final_internal_signal));
-          } else {
-            POST_MSG(4, "Fail to trace fabric module connection: %s",
-                     wrapped_net.c_str());
             entry.assignments.push_back(
-                SDC_ASSIGNMENT("# set_io", wrapped_net, location,
-                               "--> Fail to trace fabric connection"));
+                SDC_ASSIGNMENT(set_io, wrapped_net, assigned_location, "-mode",
+                               m_location_mode.at(location), "-internal_pin",
+                               final_internal_signal));
+          } else {
+            reason = stringf("Fail to trace fabric module connection: %s",
+                             wrapped_net.c_str());
+            POST_MSG(4, "%s", reason.c_str());
+            entry.comments.push_back(
+                stringf("# Failure reason: %s", reason.c_str()));
           }
           wrapped_net_i++;
         }
@@ -2674,13 +2650,11 @@ void PRIMITIVES_EXTRACTOR::write_sdc_internal_control_signal(
         entry.comments.push_back((std::string)("# Failure reason: ") + reason);
       }
     }
-  } else if (location.size() == 0) {
-    POST_MSG(4, "Pin location is not assigned");
-    entry.comments.push_back("# Pin location is not assigned");
   } else {
-    POST_MSG(4, "%s", pin.failure_reason.c_str());
-    entry.comments.push_back(
-        stringf("# Failure reason: %s", pin.failure_reason.c_str()));
+    std::string reason = stringf(
+        "Location %s does not have any mode to begin with", location.c_str());
+    POST_MSG(4, "%s", reason.c_str());
+    entry.comments.push_back(stringf("# %s", reason.c_str()));
   }
   sdc_entries.push_back(entry);
 }
@@ -2808,8 +2782,8 @@ std::string PRIMITIVES_EXTRACTOR::get_input_wrapped_net(
       if (fabric["connectivity"].contains(wrapped_net)) {
         // good
         found = true;
-        break;
       }
+      break;
     }
   }
   if (!found) {
@@ -2850,8 +2824,8 @@ std::string PRIMITIVES_EXTRACTOR::get_output_wrapped_net(
       if (fabric["connectivity"].contains(wrapped_net)) {
         // good
         found = true;
-        break;
       }
+      break;
     }
   }
   if (!found) {
@@ -3019,6 +2993,7 @@ std::vector<bool> PRIMITIVES_EXTRACTOR::check_fabric_port(
         founds.push_back(fabric.contains("connectivity") &&
                          fabric["connectivity"].contains(net));
       }
+      break;
     }
   }
   return founds;
@@ -3045,6 +3020,9 @@ void PRIMITIVES_EXTRACTOR::write_sdc_entries(
   size_t col1 = 0;
   size_t col2 = 0;
   size_t col3 = 0;
+  size_t col4 = 0;
+  size_t col5 = 0;
+  size_t col6 = 0;
   for (auto& entry : sdc_entries) {
     for (auto& assignment : entry.assignments) {
       if (assignment.str1.size() > col1) {
@@ -3055,6 +3033,15 @@ void PRIMITIVES_EXTRACTOR::write_sdc_entries(
       }
       if (assignment.str3.size() > col3) {
         col3 = assignment.str3.size();
+      }
+      if (assignment.str4.size() > col4) {
+        col4 = assignment.str4.size();
+      }
+      if (assignment.str5.size() > col5) {
+        col5 = assignment.str5.size();
+      }
+      if (assignment.str6.size() > col6) {
+        col6 = assignment.str6.size();
       }
     }
   }
@@ -3067,9 +3054,23 @@ void PRIMITIVES_EXTRACTOR::write_sdc_entries(
       file_write_string(sdc, assignment.str2, (int)(col2 + 1));
       if (assignment.str4.size()) {
         file_write_string(sdc, assignment.str3, (int)(col3 + 1));
-        file_write_string(sdc, assignment.str4);
+        if (assignment.str5.size()) {
+          log_assert(assignment.str6.size());
+          log_assert(assignment.str7.size());
+          file_write_string(sdc, assignment.str4, (int)(col4 + 1));
+          file_write_string(sdc, assignment.str5, (int)(col5 + 1));
+          file_write_string(sdc, assignment.str6, (int)(col6 + 1));
+          file_write_string(sdc, assignment.str7);
+        } else {
+          file_write_string(sdc, assignment.str4);
+          log_assert(assignment.str6.empty());
+          log_assert(assignment.str7.empty());
+        }
       } else {
         file_write_string(sdc, assignment.str3);
+        log_assert(assignment.str5.empty());
+        log_assert(assignment.str6.empty());
+        log_assert(assignment.str7.empty());
       }
       sdc << "\n";
     }

--- a/design_edit/src/primitives_extractor.h
+++ b/design_edit/src/primitives_extractor.h
@@ -77,12 +77,17 @@ struct FABRIC_CLOCK {
 */
 struct SDC_ASSIGNMENT {
   SDC_ASSIGNMENT(const std::string& s1, const std::string& s2,
-                 const std::string& s3, const std::string& s4)
-      : str1(s1), str2(s2), str3(s3), str4(s4) {}
+                 const std::string& s3, const std::string& s4,
+                 const std::string& s5 = "", const std::string& s6 = "",
+                 const std::string& s7 = "")
+      : str1(s1), str2(s2), str3(s3), str4(s4), str5(s5), str6(s6), str7(s7) {}
   const std::string str1 = "";
   const std::string str2 = "";
   const std::string str3 = "";
   const std::string str4 = "";
+  const std::string str5 = "";
+  const std::string str6 = "";
+  const std::string str7 = "";
 };
 
 struct SDC_ENTRY {


### PR DESCRIPTION
This is for auto mode/internal-signal assignment support:
- specifically for data signal from second half gearbox

This PR must merge together (or after) with https://github.com/os-fpga/FOEDAG/pull/1627 into Raptor

Testing done:
- Port this PR (+https://github.com/os-fpga/FOEDAG/pull/1627) to latest NS Raptor
- Run test/batch, test/batch_gen2 and test/batch_gen3
- Run all GJC - make sure compilation pass but I think there is issue of the project/overall-architecture