### PR TITLE
Enhance mode decision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
 
 
-set(VERSION_PATCH 335)
+set(VERSION_PATCH 336)
 
 
 project(yosys_verific_rs)


### PR DESCRIPTION
If the parameter WIDTH cannot be retrieved (seperate issue that we might be able to enhance our synthesis flow), determine the mode RATE via the data width. 

Testing done:
- Port this PR to latest NS Raptor (revert https://github.com/os-fpga/FOEDAG/pull/1628)
- Run test/batch, test/batch_gen2 and test/batch_gen3