### PR TITLE
More auto-determine support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
 
 
-set(VERSION_PATCH 337)
+set(VERSION_PATCH 338)
 
 
 project(yosys_verific_rs)

--- a/design_edit/src/primitives_extractor.cc
+++ b/design_edit/src/primitives_extractor.cc
@@ -259,7 +259,7 @@ const std::map<std::string, std::vector<PRIMITIVE_DB>> SUPPORTED_PRIMITIVES = {
           "",                                   // fast_clock
           "",                                   // core_clock
           {                                     // control_signal_map
-            {"EN", "in:f2g_in_en_{X}"}
+            {"EN", "in:f2g_in_en_{A|B}"}
           },
           "\\O"                                 // data_signal
       )},
@@ -274,7 +274,7 @@ const std::map<std::string, std::vector<PRIMITIVE_DB>> SUPPORTED_PRIMITIVES = {
           "",                                   // fast_clock
           "",                                   // core_clock
           {                                     // control_signal_map
-            {"EN", "in:f2g_in_en_{X}"}
+            {"EN", "in:f2g_in_en_{A|B}"}
           },
           "\\O"                                 // data_signal
       )},
@@ -303,7 +303,7 @@ const std::map<std::string, std::vector<PRIMITIVE_DB>> SUPPORTED_PRIMITIVES = {
           "",                                   // fast_clock
           "",                                   // core_clock
           {                                     // control_signal_map
-            {"T", "in:f2g_tx_oe_{X}"}
+            {"T", "in:f2g_tx_oe_{A|B}"}
           },
           "\\I"                                 // data_signal
       )},
@@ -331,7 +331,7 @@ const std::map<std::string, std::vector<PRIMITIVE_DB>> SUPPORTED_PRIMITIVES = {
           "",                                   // fast_clock
           "",                                   // core_clock
           {                                     // control_signal_map
-            {"T", "in:f2g_tx_oe_{X}"}
+            {"T", "in:f2g_tx_oe_{A|B}"}
           },
           "\\I"                                 // data_signal
       )},
@@ -395,10 +395,10 @@ const std::map<std::string, std::vector<PRIMITIVE_DB>> SUPPORTED_PRIMITIVES = {
           "\\PLL_CLK",                          // fast_clock
           "\\CLK_IN",                           // core_clock
           {                                     // control_signal_map
-            {"RX_RST", "in:TO_BE_DETERMINED"},
+            {"RX_RST", "in:f2g_trx_reset_n_{A|B}"},
             {"BITSLIP_ADJ", "in:TO_BE_DETERMINED"},
             {"EN", "in:TO_BE_DETERMINED"},
-            {"DATA_VALID", "out:TO_BE_DETERMINED"},
+            {"DATA_VALID", "out:g2f_rx_dvalid_{A|B}"},
             {"DPA_LOCK", "out:TO_BE_DETERMINED"},
             {"DPA_ERROR", "out:TO_BE_DETERMINED"},
             {"PLL_LOCK", "in:TO_BE_DETERMINED"}
@@ -481,8 +481,8 @@ const std::map<std::string, std::vector<PRIMITIVE_DB>> SUPPORTED_PRIMITIVES = {
           "\\PLL_CLK",                          // fast_clock
           "\\CLK_IN",                           // core_clock
           {                                     // control_signal_map
-            {"RST", "in:TO_BE_DETERMINED"},
-            {"LOAD_WORD", "in:TO_BE_DETERMINED"},
+            {"RST", "in:f2g_trx_reset_n_{A|B}"},
+            {"LOAD_WORD", "in:f2g_tx_dvalid_{A|B}"},
             {"OE_IN", "in:TO_BE_DETERMINED"},
             {"OE_OUT", "out:TO_BE_DETERMINED"},
             {"CHANNEL_BOND_SYNC_IN", "in:TO_BE_DETERMINED"},
@@ -1957,7 +1957,8 @@ void PRIMITIVES_EXTRACTOR::update_pin_info(const std::string& pin_name,
       pin->mode = stringf("RATE_%d", width);
     } else if (primitive->data_width > 0) {
       pin->mode = stringf("RATE_%d", primitive->data_width);
-    } else if (primitive->parameters.find("\\DATA_RATE") != primitive->parameters.end()) {
+    } else if (primitive->parameters.find("\\DATA_RATE") !=
+               primitive->parameters.end()) {
       pin->mode = get_param_string(primitive->parameters.at("\\DATA_RATE"));
     }
     if (pin->mode.size() == 0) {
@@ -1967,30 +1968,9 @@ void PRIMITIVES_EXTRACTOR::update_pin_info(const std::string& pin_name,
     log_assert(pin->mode == "SDR" || pin->mode == "DDR" ||
                pin->mode.find("RATE_") == 0);
   }
-  if (primitive->db->name == "\\CLK_BUF" ||
-      primitive->db->name == "\\O_SERDES_CLK") {
-    std::string name = get_original_name(primitive->name);
-    bool found = false;
-    for (auto& instance : m_instances) {
-      if (instance->name == name) {
-        found = true;
-        if (instance->parameters.find("ROUTE_TO_FABRIC_CLK") ==
-            instance->parameters.end()) {
-          if (primitive->db->name == "\\CLK_BUF") {
-            pin->skip_reason = "The clock is not used by fabric";
-          } else {
-            pin->skip_reason = "The clock is Gearbox internal fast clock";
-          }
-        } else {
-          pin->skip_reason = "Temporarily disable all clock constraint";
-        }
-        break;
-      }
-    }
-    log_assert(found);
-  } else if (primitive->db->name == "\\I_BUF_DS" ||
-             primitive->db->name == "\\O_BUF_DS" ||
-             primitive->db->name == "\\O_BUFT_DS") {
+  if (primitive->db->name == "\\I_BUF_DS" ||
+      primitive->db->name == "\\O_BUF_DS" ||
+      primitive->db->name == "\\O_BUFT_DS") {
     std::string secondary_port =
         primitive->db->name == "\\I_BUF_DS" ? "\\I_N" : "\\O_N";
     log_assert(primitive->connections.find(secondary_port) !=
@@ -2565,10 +2545,10 @@ void PRIMITIVES_EXTRACTOR::write_sdc_internal_control_signal(
                 assigned_location[assigned_location.size() - 1] == 'N' ? "B"
                                                                        : "A";
             std::string final_internal_signal = internal_signal_name;
-            size_t index = final_internal_signal.find("{X}");
+            size_t index = final_internal_signal.find("{A|B}");
             if (index != std::string::npos) {
               final_internal_signal =
-                  final_internal_signal.replace(index, 3, AB);
+                  final_internal_signal.replace(index, 5, AB);
             }
             if (wrapped_nets.size() > 1) {
               index = final_internal_signal.find("{[");
@@ -2856,7 +2836,7 @@ std::string PRIMITIVES_EXTRACTOR::get_fabric_data(
   for (auto& inst : m_instances) {
     if (std::find(inst->linked_objects.begin(), inst->linked_objects.end(),
                   object) != inst->linked_objects.end()) {
-      if (inst->module != "WIRE") {
+      if (inst->module != "WIRE" && inst->module != "CLK_BUF") {
         instance = inst;
       }
     }


### PR DESCRIPTION
1. Add more internal control signals in the extractor's data-driven table. 
2. Update special syntax (internal code - not affecting user result)
3. Support data assignment for clock

Testing done:
- Port this PR to latest NS Raptor
- Run test/batch, test/batch_gen2 and test/batch_gen3