### PR TITLE
Support different fast clock priority

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(VERSION_MINOR 0)
 
 
 
-set(VERSION_PATCH 362)
+set(VERSION_PATCH 363)
 
 
 


### PR DESCRIPTION
In certain cases, we need to use certain primitive core clock as fast clock, but in certain case (if other primitive in the chain has an explicit fast clock port) then we do not need to use its core clock as fast clock. 