### PR TITLE
Support PLL VCO output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(VERSION_MINOR 0)
 
 
 
-set(VERSION_PATCH 366)
+set(VERSION_PATCH 367)
 
 
 

--- a/design_edit/src/primitives_extractor.h
+++ b/design_edit/src/primitives_extractor.h
@@ -176,7 +176,8 @@ class PRIMITIVES_EXTRACTOR {
       std::vector<SDC_ENTRY*>& sdc_entries,
       const nlohmann::json& wrapped_instances, const std::string& module,
       const std::string& linked_object, const std::string& location,
-      const std::string& port, const std::string& internal_signal);
+      const std::string& port, const std::string& internal_signal,
+      bool is_in_dir);
   bool validate_location(const std::string& location, PIN_PARSER& pin);
   std::string get_assigned_location(SDC_ENTRY*& entry, const std::string& rule,
                                     const std::string& location,


### PR DESCRIPTION
1. This is to support PLL VCO output which modeled as FAST_CLK port

2. Accurately set set control pin mode (mode might be set wrong when the pin is used in bidirectional, but so far it seems not impact the bitstream negatively - still we should fix it).  