### PR TITLE
Update design editor config.json flow after extra wires are removed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(VERSION_MINOR 0)
 
 
 
-set(VERSION_PATCH 371)
+set(VERSION_PATCH 372)
 
 
 


### PR DESCRIPTION
With recent change in design editor that remove extra wires, which had broken existing IO_DDR in config.json.

This minor change is to keep up with that code and simplify the existing flow in handling config.json with design editor changes. 

(p/s: keep original link_instance_recursively() function in this PR)